### PR TITLE
feat(detect): Add F# project (.fsproj) support and fixtures (#63)

### DIFF
--- a/crates/cli/tests/fixtures/single-language/dotnet-fsproj-api/FSharpApi.fsproj
+++ b/crates/cli/tests/fixtures/single-language/dotnet-fsproj-api/FSharpApi.fsproj
@@ -1,0 +1,13 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="Program.fs" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="8.0.0" />
+  </ItemGroup>
+</Project>

--- a/crates/cli/tests/fixtures/single-language/dotnet-fsproj-api/Program.fs
+++ b/crates/cli/tests/fixtures/single-language/dotnet-fsproj-api/Program.fs
@@ -1,0 +1,10 @@
+open System
+open Microsoft.AspNetCore.Builder
+
+let builder = WebApplication.CreateBuilder()
+let app = builder.Build()
+
+app.MapGet("/", Func<string>(fun () -> "F# API Server")) |> ignore
+app.MapGet("/health", Func<string>(fun () -> "ok")) |> ignore
+
+app.Run()

--- a/crates/cli/tests/fixtures/single-language/dotnet-fsproj-api/universalbuild.json
+++ b/crates/cli/tests/fixtures/single-language/dotnet-fsproj-api/universalbuild.json
@@ -1,0 +1,59 @@
+[
+  {
+    "build": {
+      "cache": [
+        ".nuget/packages",
+        "bin",
+        "obj"
+      ],
+      "commands": [
+        "dotnet restore",
+        "dotnet publish -c Release -o out"
+      ],
+      "env": {
+        "DOTNET_CLI_HOME": "/root",
+        "DOTNET_CLI_TELEMETRY_OPTOUT": "1",
+        "DOTNET_NOLOGO": "1",
+        "DOTNET_SKIP_FIRST_TIME_EXPERIENCE": "1"
+      },
+      "packages": [
+        "dotnet-8-sdk",
+        "ca-certificates"
+      ]
+    },
+    "metadata": {
+      "build_system": ".NET",
+      "framework": "ASP.NET Core",
+      "language": "F#",
+      "project_name": "app",
+      "reasoning": "Detected from FSharpApi.fsproj"
+    },
+    "runtime": {
+      "command": [
+        "dotnet",
+        "/app/FSharpApi.dll"
+      ],
+      "copy": [
+        {
+          "from": "out/",
+          "to": "/app"
+        }
+      ],
+      "env": {
+        "ASPNETCORE_URLS": "http://0.0.0.0:5000"
+      },
+      "health": {
+        "endpoint": "/health"
+      },
+      "packages": [
+        "aspnet-8-runtime",
+        "ca-certificates"
+      ],
+      "ports": [
+        5000
+      ],
+      "workdir": "/app"
+    },
+    "version": "1.0"
+  }
+]

--- a/crates/cli/tests/fixtures/single-language/dotnet-fsproj-cli/FSharpCli.fsproj
+++ b/crates/cli/tests/fixtures/single-language/dotnet-fsproj-cli/FSharpCli.fsproj
@@ -1,0 +1,10 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net8.0</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="Program.fs" />
+  </ItemGroup>
+</Project>

--- a/crates/cli/tests/fixtures/single-language/dotnet-fsproj-cli/Program.fs
+++ b/crates/cli/tests/fixtures/single-language/dotnet-fsproj-cli/Program.fs
@@ -1,0 +1,1 @@
+printfn "Hello from F#!"

--- a/crates/cli/tests/fixtures/single-language/dotnet-fsproj-cli/universalbuild.json
+++ b/crates/cli/tests/fixtures/single-language/dotnet-fsproj-cli/universalbuild.json
@@ -1,0 +1,53 @@
+[
+  {
+    "build": {
+      "cache": [
+        ".nuget/packages",
+        "bin",
+        "obj"
+      ],
+      "commands": [
+        "dotnet restore",
+        "dotnet publish -c Release -o out"
+      ],
+      "env": {
+        "DOTNET_CLI_HOME": "/root",
+        "DOTNET_CLI_TELEMETRY_OPTOUT": "1",
+        "DOTNET_NOLOGO": "1",
+        "DOTNET_SKIP_FIRST_TIME_EXPERIENCE": "1"
+      },
+      "packages": [
+        "dotnet-8-sdk",
+        "ca-certificates"
+      ]
+    },
+    "metadata": {
+      "build_system": ".NET",
+      "language": "F#",
+      "project_name": "app",
+      "reasoning": "Detected from FSharpCli.fsproj"
+    },
+    "runtime": {
+      "command": [
+        "dotnet",
+        "/app/FSharpCli.dll"
+      ],
+      "copy": [
+        {
+          "from": "out/",
+          "to": "/app"
+        }
+      ],
+      "env": {},
+      "packages": [
+        "aspnet-8-runtime",
+        "ca-certificates"
+      ],
+      "ports": [
+        5000
+      ],
+      "workdir": "/app"
+    },
+    "version": "1.0"
+  }
+]

--- a/crates/detect/src/parsers/manifest/csproj.rs
+++ b/crates/detect/src/parsers/manifest/csproj.rs
@@ -129,3 +129,116 @@ fn parse_csproj_deps(content: &str) -> Vec<Dependency> {
 inventory::submit! {
     crate::registry::ManifestParserEntry(|| Box::new(CsprojParser))
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::traits::ManifestParser;
+
+    #[test]
+    fn test_parse_csproj() {
+        let parser = CsprojParser;
+        let content = r#"<Project Sdk="Microsoft.NET.Sdk.Web">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="8.0.0" />
+  </ItemGroup>
+</Project>"#;
+
+        let manifest = parser.parse(Path::new("App.csproj"), content).unwrap();
+        assert_eq!(manifest.language, CSHARP);
+        assert_eq!(manifest.build_system, DOTNET_BS);
+        assert_eq!(manifest.runtime, DOTNET_RT);
+        assert_eq!(
+            manifest.build.packages,
+            vec!["dotnet-8-sdk", "ca-certificates"]
+        );
+        assert_eq!(
+            manifest.runtime_config.packages,
+            vec!["aspnet-8-runtime", "ca-certificates"]
+        );
+        assert_eq!(
+            manifest.runtime_config.entrypoint,
+            Some("dotnet /app/App.dll".into())
+        );
+        assert_eq!(manifest.dependencies.len(), 1);
+        assert_eq!(
+            manifest.dependencies[0].name,
+            "Microsoft.AspNetCore.OpenApi"
+        );
+    }
+
+    #[test]
+    fn test_parse_fsproj() {
+        let parser = CsprojParser;
+        let content = r#"<Project Sdk="Microsoft.NET.Sdk.Web">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="8.0.0" />
+  </ItemGroup>
+</Project>"#;
+
+        let manifest = parser
+            .parse(Path::new("FSharpApi.fsproj"), content)
+            .unwrap();
+        assert_eq!(manifest.language, FSHARP);
+        assert_eq!(manifest.build_system, DOTNET_BS);
+        assert_eq!(
+            manifest.runtime_config.entrypoint,
+            Some("dotnet /app/FSharpApi.dll".into())
+        );
+        assert_eq!(manifest.dependencies.len(), 1);
+    }
+
+    #[test]
+    fn test_parse_fsproj_cli() {
+        let parser = CsprojParser;
+        let content = r#"<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net8.0</TargetFramework>
+  </PropertyGroup>
+</Project>"#;
+
+        let manifest = parser
+            .parse(Path::new("FSharpCli.fsproj"), content)
+            .unwrap();
+        assert_eq!(manifest.language, FSHARP);
+        assert_eq!(manifest.dependencies.len(), 0);
+        assert_eq!(
+            manifest.runtime_config.entrypoint,
+            Some("dotnet /app/FSharpCli.dll".into())
+        );
+    }
+
+    #[test]
+    fn test_rejects_non_project_content() {
+        let parser = CsprojParser;
+        let result = parser.parse(Path::new("Readme.fsproj"), "Just some text");
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn test_fallback_dotnet_version() {
+        let parser = CsprojParser;
+        let content = r#"<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+  </PropertyGroup>
+</Project>"#;
+
+        let manifest = parser.parse(Path::new("Lib.csproj"), content).unwrap();
+        assert_eq!(
+            manifest.build.packages,
+            vec!["dotnet-sdk", "ca-certificates"]
+        );
+        assert_eq!(
+            manifest.runtime_config.packages,
+            vec!["dotnet-runtime", "ca-certificates"]
+        );
+    }
+}


### PR DESCRIPTION
## Summary
- Add E2E test fixtures for F# web API (`dotnet-fsproj-api`) and console app (`dotnet-fsproj-cli`) projects
- Add 5 unit tests for `CsprojParser` covering F# `.fsproj` file parsing (language detection, build/runtime config, dependency extraction, fallback versions, and rejection of non-project content)
- The existing `CsprojParser` already handles `.fsproj` files via extension-based detection — this PR adds test coverage and fixture validation

Closes #63

## Test plan
- [x] All 391 tests pass (`cargo nextest run --features cuda`)
- [x] Clippy clean with zero warnings (`cargo clippy --all-targets --features cuda -- -D warnings`)
- [x] Static E2E tests validate both new fixtures against `universalbuild.json` snapshots
- [x] Container E2E tests build and health-check the F# API fixture successfully
- [x] Unit tests verify CsprojParser produces correct `Manifest` for both `.csproj` and `.fsproj` inputs

🤖 Generated with [Claude Code](https://claude.com/claude-code)